### PR TITLE
Add progress meter

### DIFF
--- a/lib/EventStore/Tiny.pm
+++ b/lib/EventStore/Tiny.pm
@@ -77,6 +77,14 @@ sub init_state {
     return clone($self->init_data);
 }
 
+sub init_cache {
+    my $self = shift;
+    return if not defined $self->cache_distance
+        or defined $self->_cached_snapshot;
+    $self->snapshot->state;
+    return 1;
+}
+
 sub snapshot {
     my ($self, $timestamp) = @_;
     my $state = $self->init_state;
@@ -232,6 +240,10 @@ Standard constructor. Understands all attributes as arguments. For most use case
 =item init_data
 
 A hashref representing the initial state. B<Default: C<{}>>
+
+=item init_cache
+
+When this method is called, the cache will be filled.
 
 =item cache_distance
 

--- a/lib/EventStore/Tiny/ProgressMeter.pm
+++ b/lib/EventStore/Tiny/ProgressMeter.pm
@@ -6,8 +6,18 @@ use warnings;
 use Class::Tiny {
     events_per_step     => undef,
     seconds_per_step    => undef,
-    report_progress     => sub {die "report_progress required\n"},
+    report_progress     => sub {die "report_progress is required\n"},
 };
+
+sub BUILD {
+    my $self = shift;
+
+    # Check non-lazy
+    $self->report_progress;
+
+    # Return nothing (will be ignored anyway)
+    return;
+}
 
 1;
 

--- a/lib/EventStore/Tiny/ProgressMeter.pm
+++ b/lib/EventStore/Tiny/ProgressMeter.pm
@@ -1,0 +1,53 @@
+package EventStore::Tiny::ProgressMeter;
+
+use strict;
+use warnings;
+
+use Class::Tiny {
+    events_per_step     => undef,
+    seconds_per_step    => undef,
+    report_progress     => sub {die "report_progress required\n"},
+};
+
+1;
+
+=pod
+
+=encoding utf-8
+
+=head1 NAME
+
+EventStore::Tiny::ProgressMeter
+
+=head1 REFERENCE
+
+A class a progress meter should inherit to be called while events are processed. A typical use is to report the progress of the (possibly long-running) initial event application.
+
+=head2 events_per_step
+
+Defines the number of events inbetween progress meter calls. A value of 100 means that the progress meter is called every 100 event applications.
+
+=head2 seconds_per_step
+
+Defines the number of seconds inbetween progress meter calls. A value of 2 means that the progress meter is called every 2 seconds.
+
+=head2 report_progress
+
+    $progress_meter->report_progress(sub {
+        my ($total, $current) = @_;
+        say "Progress: $current / $total events";
+    });
+
+A subroutine reference (callback) which will be called to report application progress.
+
+=head1 SEE ALSO
+
+L<EventStore::Tiny>
+
+=head1 COPYRIGHT AND LICENSE
+
+Copyright (c) 2018 Mirko Westermeier (mail: mirko@westermeier.de)
+
+Released under the MIT License (see LICENSE.txt for details).
+
+=cut

--- a/t/2_integration/caching.t
+++ b/t/2_integration/caching.t
@@ -21,6 +21,11 @@ subtest "Cache size: $cs" => sub {
     my $init_ec = $cs + 10;
     $est->store_event('EventApplied') for 1 .. $init_ec;
 
+    # Fill the cache for the first time
+    ok ! defined $est->_cached_snapshot, 'Cached snapshot empty before';
+    $est->init_cache;
+    ok defined($est->_cached_snapshot), 'Cached snapshot now exists';
+
     # Snapshot: events applied
     is $est->snapshot->state->{x} => $init_ec, 'Correct state';
     is $ea_count => $init_ec, "$init_ec event applications";
@@ -59,6 +64,10 @@ subtest 'Caching disabled' => sub {
     $est->events->events([]);
     $est->_cached_snapshot(undef);
     $est->cache_distance(undef);
+
+    # Cache initialization does nothing
+    is $est->init_cache => undef, 'init_cache unsuccessuful';
+    is $est->_cached_snapshot => undef, 'No snapshot cached';
 
     # Add some events
     my $ec = 17;

--- a/t/2_integration/caching_progress.t
+++ b/t/2_integration/caching_progress.t
@@ -1,0 +1,70 @@
+use strict;
+use warnings;
+
+use Test::More;
+
+use EventStore::Tiny;
+use_ok 'EventStore::Tiny::ProgressMeter';
+
+subtest 'Report callback of ES::T::ProgressMeter' => sub {
+    eval {EventStore::Tiny::ProgressMeter->new};
+    like $@ => qr/report_progress is required/, 'report_progress is required';
+};
+
+subtest 'Progress by number of events' => sub {
+    my $est = EventStore::Tiny->new(logger => undef);
+
+    # Prepare meter (log)
+    my $meter_log = '';
+    $est->progress_meter(EventStore::Tiny::ProgressMeter->new(
+        events_per_step => 2,
+        report_progress => sub {
+            my ($total, $current) = @_;
+            $meter_log .= " $current/$total";
+        },
+    ));
+
+    # Prepare events
+    $est->register_event(EventProcessed => sub {shift->{count}++});
+    $est->store_event('EventProcessed') for 1 .. 10;
+
+    # Initialize
+    $est->init_cache;
+
+    # Check result
+    is $est->snapshot->state->{count} => 10, 'Correct transformation';
+    is $meter_log => ' 1/10 3/10 5/10 7/10 9/10', 'Correct meter log';
+};
+
+subtest 'Progress by number of seconds' => sub {
+    my $est = EventStore::Tiny->new(logger => undef);
+
+    # Prepare meter (log)
+    my $meter_log = '';
+    $est->progress_meter(EventStore::Tiny::ProgressMeter->new(
+        seconds_per_step    => 1,
+        report_progress     => sub {
+            my ($total, $current) = @_;
+            $meter_log .= " $current/$total";
+        },
+    ));
+
+    # Prepare events
+    $est->register_event(TimePassed => sub {
+        my ($state, $data) = @_;
+        sleep $data->{sleep};
+        $state->{count}++;
+    });
+    $est->store_event(TimePassed => {sleep => 0}) for 1 .. 3;
+    $est->store_event(TimePassed => {sleep => 1});
+    $est->store_event(TimePassed => {sleep => 0}) for 1 .. 4;
+
+    # Initialize
+    $est->init_cache;
+
+    # Check result
+    is $est->snapshot->state->{count} => 8, 'Correct transformation';
+    is $meter_log => ' 1/8 4/8', 'Correct meter log';
+};
+
+done_testing;


### PR DESCRIPTION
Add a possibility to register a callback to report progress of the (possibly long-running) event application before the cache is beeing built.

Closes #7.